### PR TITLE
emit same lexer code for same lexer source, by sorting edges

### DIFF
--- a/nex.go
+++ b/nex.go
@@ -655,7 +655,7 @@ func gen(out *bufio.Writer, x *rule) {
 		var list edges
 		list = append(list, v.e...)
 		sort.Sort(list)
-		for _, e := range edges {
+		for _, e := range list {
 			m := e.dst.n
 			switch e.kind {
 			case kRune:


### PR DESCRIPTION
problem was, that re-compiling same lexer source would often result in different code, with just the case 
statements permuted randomly... so, better to sort them first so that they're always output in the same order, resulting in unchanged code.
