### PR TITLE
Add generic parse result interface to enhance Go Yacc integration.

### DIFF
--- a/nex.go
+++ b/nex.go
@@ -936,6 +936,8 @@ type Lexer struct {
   // Since then, I introduced the built-in Line() and Column() functions.
   l, c int
 
+  parseResult interface{}
+
   // The following line makes it easy for scripts to insert fields in the
   // generated code.
   // [NEX_END_OF_LEXER_STRUCT]


### PR DESCRIPTION
Go Yacc parse results currently best be passed back through the lexer, [as mentioned by Russ Cox](https://groups.google.com/d/msg/golang-dev/nemcZF_KyYg/PlHr8DG4togJ). Although this isn't a nice practice – in terms of decoupling and accompanying separation of concerns – it offers a midway until Go Yacc allows for 'proper' parser outcome communication.

Nex appears to recognize this situation by [offering a 'hook'](https://github.com/blynn/nex/blob/master/nex.go#L939-L941) in the generated source code. However, this also introduces a separate search and replace step, most likely done in a Makefile build step [or otherwise](https://github.com/blynn/nex/blob/master/tacky/build.sh#L5). Although workable, I think Go offers one step better by means of the ```interface{}``` 'type'. Which is what I'm proposing through this pull request.

As an example, code like below could be added to bottom of the `.nex` file:

```go
//

package parser 

func MyParse(input string) (ast.Node, int) {
	inputReader := strings.NewReader(input) // ...might need import, depending on Nex -s switch usage

	lexer := NewLexer(inputReader)
	parseOutcome := yyParse(lexer)

	return lexer.parseResult, parseOutcome
}
```

Mind you, the `ast.Node` type is being returned, which could be replaced with anything to your liking. One could also wholly place the 'burden' of type assertion back to the caller by changing that to be `interface{}`. Which adds to my point.

Well, lot of words for a small change – :smiley: Hope I've got my point of view across.