### PR TITLE
slightly change generated code to pass "go vet"

### DIFF
--- a/nex.go
+++ b/nex.go
@@ -727,6 +727,8 @@ func writeFamily(out *bufio.Writer, node *rule, lvl int) {
 		out.WriteString("}\n")
 	}
 	tab()
+	fmt.Fprintf(out, "OUTER%s%d:\n", node.id, lvl)
+	tab()
 	fmt.Fprintf(out, "for { switch yylex.next(%v) {\n", lvl)
 	for i, x := range node.kid {
 		tab()
@@ -738,14 +740,16 @@ func writeFamily(out *bufio.Writer, node *rule, lvl int) {
 			tab()
 			out.WriteString("\t" + x.code + "\n")
 		}
-		tab()
-		out.WriteString("\tcontinue\n")
 		lvl--
 	}
 	tab()
+	out.WriteString("\tdefault:\n")
+	tab()
+	fmt.Fprintf(out, "\t\t break OUTER%s%d\n", node.id, lvl)
+	tab()
 	out.WriteString("\t}\n")
 	tab()
-	out.WriteString("\tbreak\n")
+	out.WriteString("\tcontinue\n")
 	tab()
 	out.WriteString("}\n")
 	tab()


### PR DESCRIPTION
previously rules which explicitly called return
would result in generated code which did not
pass "go vet" because there was an unreachable continue
this change, should be equivalent, the continue in each
block has been pushed the first statement after the
switch.  the break, previously after the switch, has
been put inside a new default block at the end of
the switch.  the break now needs a label to refer
to the correct for loop to break out of.