### PR TITLE
Fix panic caused by .Line()

### DIFF
--- a/nex.go
+++ b/nex.go
@@ -1087,6 +1087,9 @@ func (yylex *Lexer) Text() string {
 // Line returns the current line number.
 // The first line is 0.
 func (yylex *Lexer) Line() int {
+  if len(yylex.stack) == 0 {
+    return 0
+  }
   return yylex.stack[len(yylex.stack) - 1].line
 }
 


### PR DESCRIPTION
```
panic: runtime error: index out of range
goroutine 1 [running]:
main.Lexer.Error(0x8202be060, 0x82029a240, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x820232300, ...)
	/lexer.go:2225 +0x492
```
```
func (yylex Lexer) Error(e string) {
	fmt.Printf("Line %d, column %d: %s", yylex.Line() + 1,  yylex.Column() + 1, e)
}
```
In case of *lex $end(0)*