### PR TITLE
prepare main() for separation from lib portion of code

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var outFilename string
+var nfadotFile, dfadotFile string
+var autorun, standalone, customError bool
+
+func main() {
+	flag.StringVar(&outFilename, "o", "", `output file`)
+	flag.BoolVar(&standalone, "s", false, `standalone code; NN_FUN macro substitution, no Lex() method`)
+	flag.BoolVar(&customError, "e", false, `custom error func; no Error() method`)
+	flag.BoolVar(&autorun, "r", false, `run generated program`)
+	flag.StringVar(&nfadotFile, "nfadot", "", `show NFA graph in DOT format`)
+	flag.StringVar(&dfadotFile, "dfadot", "", `show DFA graph in DOT format`)
+	flag.Parse()
+
+	nfadot = createDotFile(nfadotFile)
+	dfadot = createDotFile(dfadotFile)
+	defer func() {
+		if nfadot != nil {
+			dieErr(nfadot.Close(), "Close")
+		}
+		if dfadot != nil {
+			dieErr(dfadot.Close(), "Close")
+		}
+	}()
+	infile, outfile := os.Stdin, os.Stdout
+	var err error
+	if flag.NArg() > 0 {
+		dieIf(flag.NArg() > 1, "nex: extraneous arguments after", flag.Arg(0))
+		dieIf(strings.HasSuffix(flag.Arg(0), ".go"), "nex: input filename ends with .go:", flag.Arg(0))
+		basename := flag.Arg(0)
+		n := strings.LastIndex(basename, ".")
+		if n >= 0 {
+			basename = basename[:n]
+		}
+		infile, err = os.Open(flag.Arg(0))
+		dieErr(err, "nex")
+		defer infile.Close()
+		if !autorun {
+			if outFilename == "" {
+				outfile, err = os.Create(basename + ".nn.go")
+			} else {
+				outfile, err = os.Create(outFilename)
+			}
+			dieErr(err, "nex")
+			defer outfile.Close()
+		}
+	}
+	if autorun {
+		tmpdir, err := ioutil.TempDir("", "nex")
+		dieIf(err != nil, "tempdir:", err)
+		defer func() {
+			dieErr(os.RemoveAll(tmpdir), "RemoveAll")
+		}()
+		outfile, err = os.Create(tmpdir + "/lets.go")
+		dieErr(err, "nex")
+		defer outfile.Close()
+	}
+	process(outfile, infile)
+	if autorun {
+		c := exec.Command("go", "run", outfile.Name())
+		c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+		dieErr(c.Run(), "go run")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -64,7 +65,10 @@ func main() {
 		dieErr(err, "nex")
 		defer outfile.Close()
 	}
-	process(outfile, infile)
+	err = process(outfile, infile)
+	if err != nil {
+		log.Fatal(err)
+	}
 	if autorun {
 		c := exec.Command("go", "run", outfile.Name())
 		c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr


### PR DESCRIPTION
switched flags to XXXVar(pointer) so the dereferences aren't necessary

Moves main() away from the rest of the code. This is helpful so that the rest of code can be turned into self-contained packages if desired.