### PR TITLE
add prefix argument fixes #23

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -88,6 +88,10 @@ and must run `nex` without the `-s` option:
 We could avoid defining a struct by using globals instead, but even then we
 need a throwaway definition of yySymType.
 
+The yy prefix can be modified by adding `-y` option. When using yacc, it must use the same prefix:
+
+ $ nex -p YY lc.nex && go tool yacc -p YY && go run lc.nn.go y.go
+
 == Toy Pascal ==
 
 The Flex manual also exhibits a http://flex.sourceforge.net/manual/Simple-Examples.html[scanner for a toy Pascal-like language],

--- a/main.go
+++ b/main.go
@@ -12,8 +12,16 @@ import (
 var outFilename string
 var nfadotFile, dfadotFile string
 var autorun, standalone, customError bool
+var prefix string
+
+var prefixReplacer *strings.Replacer
+
+func init() {
+	prefixReplacer = strings.NewReplacer()
+}
 
 func main() {
+	flag.StringVar(&prefix, "p", "yy", "name prefix to use in generated code")
 	flag.StringVar(&outFilename, "o", "", `output file`)
 	flag.BoolVar(&standalone, "s", false, `standalone code; NN_FUN macro substitution, no Lex() method`)
 	flag.BoolVar(&customError, "e", false, `custom error func; no Error() method`)
@@ -21,6 +29,10 @@ func main() {
 	flag.StringVar(&nfadotFile, "nfadot", "", `show NFA graph in DOT format`)
 	flag.StringVar(&dfadotFile, "dfadot", "", `show DFA graph in DOT format`)
 	flag.Parse()
+
+	if len(prefix) > 0 {
+		prefixReplacer = strings.NewReplacer("yy", prefix)
+	}
 
 	nfadot = createDotFile(nfadotFile)
 	dfadot = createDotFile(dfadotFile)


### PR DESCRIPTION
This makes it possible to modify the yy prefix on all variables. If you are using this with yacc, it must use the same prefix or compile errors will occur.

Example usage:

`-> % nex -p YY desk.nex && go tool yacc -p YY desk.y && go run desk.nn.go y.go`