### PR TITLE
add test case about broken regex matching

### DIFF
--- a/test/bug50.nex
+++ b/test/bug50.nex
@@ -1,0 +1,23 @@
+/[ \t\n]/	{ /* skip over whitespace */ }
+/[a-z]([a-z0-9:]*[a-z0-9]+)?/
+		{
+			s := yylex.Text()
+			fmt.Printf("TEXT: %s\n", s)
+		}
+/#[^\n]*/
+		{
+			s := yylex.Text()
+			fmt.Printf("COMMENT: %s\n", s)
+		}
+/./		{
+			s := yylex.Text()
+			fmt.Printf("ERROR: %s\n", s)
+		}
+//
+package main
+import ("fmt";"os")
+type yySymType struct { l, c int }
+func main() {
+	lex := NewLexer(os.Stdin)
+	NN_FUN(lex)
+}

--- a/test/nex_test.go
+++ b/test/nex_test.go
@@ -259,6 +259,7 @@ rect 11 12 16 17
 `},
 		{"peter2.nex", "###\n#\n####\n", "rect 1 4 1 2\nrect 1 2 2 3\nrect 1 5 3 4\n"},
 		{"u.nex", "١ + ٢ + ... + ١٨ = 一百五十三", "1 + 2 + ... + 18 = 153"},
+		{"bug50.nex", "# comment 1\nhello42:\n# comment 2\n\na\nblah:42x\n", "COMMENT: # comment 1\nTEXT: hello42\nERROR: :\nCOMMENT: # comment 2\nTEXT: a\nTEXT: blah:42x\n"},
 	} {
 		cmd := exec.Command(nexBin, "-r", "-s", x.prog)
 		cmd.Stdin = strings.NewReader(x.in)


### PR DESCRIPTION
I discovered a situation where the regex does not match correctly. The
problem is that a regex like:

```/[a-z]([a-z0-9:]*[a-z0-9]+)?/```

can match a string (as quoted) with a trailing colon like:

"example42:"

Unfortunately this is wrong. This adds a test case which should pass
when this bug is fixed.

Discussion exists in: https://github.com/blynn/nex/issues/50