### PR TITLE
prototype: no channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-export GOPATH     := $(abspath ../..)
-export NEX        := $(abspath ../../bin/nex)
+export GOPATH     := $(abspath ../../../..)
+export NEX        := $(abspath ../../../../bin/nex)
 
 all: $(NEX) test
 
 $(NEX): main.go nex.go
-	go fmt nex
-	go install nex
+	go fmt github.com/blynn/nex
+	go install github.com/blynn/nex
 
 test: $(NEX) $(shell find test -type f)
-	go fmt nex nex/test
-	go test nex nex/test
+	go fmt github.com/blynn/nex github.com/blynn/nex/test
+	go test github.com/blynn/nex github.com/blynn/nex/test
 
 clean:
 	rm -f $(NEX)


### PR DESCRIPTION
Partial implementation of discussion in #38 

This works just fine for NN_FUN style lex; but it would need significantly more work to support `writeLex` correctly.  I don't understand the internals enough to make much more progress on this myself tho.

1) `writeLex` generated code needs to propagate an int return value; `nex_test8/tmp.go` produces a compile error in this branch. I don't actually know what this return value is used for, since `Lex` is defined to always return 0.

2) In general, the way state is captured via closure in generated `scan` is probably not amenable to resuming the scan after escaping via panic-- the channel / goroutine approach sort of gives you this for "free".  But again, I don't really understand the internals that well.