### PR TITLE
Remove unnecessary busy waiting

### DIFF
--- a/nex.go
+++ b/nex.go
@@ -901,9 +901,6 @@ dollar:  // Handle $.
               }
               case stopped = <- ch_stop: {
               }
-              default: {
-                // nothing
-              }
             }
             if stopped||sent {
               break

--- a/nex.go
+++ b/nex.go
@@ -893,17 +893,10 @@ dollar:  // Handle $.
           text := string(buf[:matchn])
           buf = buf[matchn:]
           matchn = -1
-          for {
-            sent := false
-            select {
-              case ch <- frame{matchi, text, line, column}: {
-                sent = true
-              }
-              case stopped = <- ch_stop: {
-              }
+          select {
+            case ch <- frame{matchi, text, line, column}: {
             }
-            if stopped||sent {
-              break
+            case stopped = <- ch_stop: {
             }
           }
           if stopped {


### PR DESCRIPTION
While fuzzing the mgmt[0] MCL lexer/parser I observed nex performing
bad when used via go-fuzz. When calling the lexer myself from a normal
main function I got acceptable execution speeds, but when utilizing it
via go-fuzz the execution speeds were much worse. I debugged the issue
with the go-fuzz developers[1] and @dvyukov figured out why this is
happening.

go-fuzz sets GOMAXPROCS to 1 in each worker. When only using one thread
to schedule nex code, the busy waiting loop will hog a lot of CPU time
and it will take quite some time for the other go-routines to be able
to unblock the busy-waiting go routine.

[0] https://github.com/purpleidea/mgmt
[1] https://github.com/dvyukov/go-fuzz/issues/286