### PR TITLE
Update `nex` for go modules and fix linter (`revive` and `staticcheck`) issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module nex
+
+go 1.23.4

--- a/nex.go
+++ b/nex.go
@@ -937,8 +937,8 @@ func NewLexer(in io.Reader) *Lexer {
   return NewLexerWithInit(in, nil)
 }
 
-func (yyLex *Lexer) Stop() {
-  yyLex.chStop <- true
+func (yylex *Lexer) Stop() {
+  yylex.chStop <- true
 }
 
 // Text returns the matched text.

--- a/nex.go
+++ b/nex.go
@@ -789,8 +789,6 @@ type Lexer struct {
   // Since then, I introduced the built-in Line() and Column() functions.
   l, c int
 
-  parseResult interface{}
-
   // The following line makes it easy for scripts to insert fields in the
   // generated code.
   // [NEX_END_OF_LEXER_STRUCT]

--- a/nex.go
+++ b/nex.go
@@ -827,7 +827,7 @@ func NewLexerWithInit(in io.Reader, initFun func(*Lexer)) *Lexer {
         mark[st] = true
         // As we're at the start of input, follow all ^ transitions and append to our list of start states.
         st = family[i].startf[st]
-        if -1 == st || mark[st] { break }
+        if st == -1 || mark[st] { break }
         // We only check for a match after at least one transition.
         checkAccept(i, st)
       }
@@ -849,7 +849,7 @@ func NewLexerWithInit(in io.Reader, initFun func(*Lexer)) *Lexer {
         var nextState [][2]int
         for _, x := range state {
           x[1] = family[x[0]].f[x[1]](r)
-          if -1 == x[1] { continue }
+          if x[1] == -1 { continue }
           nextState = append(nextState, x)
           checkAccept(x[0], x[1])
         }
@@ -861,7 +861,7 @@ dollar:  // Handle $.
           for {
             mark[x[1]] = true
             x[1] = family[x[0]].endf[x[1]]
-            if -1 == x[1] || mark[x[1]] { break }
+            if x[1] == -1 || mark[x[1]] { break }
             if checkAccept(x[0], x[1]) {
               // Unlike before, we can break off the search. Now that we're at the end, there's no need to maintain the state of each DFA.
               break dollar

--- a/nex.go
+++ b/nex.go
@@ -784,11 +784,6 @@ type Lexer struct {
   stack []frame
   stale bool
 
-  // The 'l' and 'c' fields were added for
-  // https://github.com/wagerlabs/docker/blob/65694e801a7b80930961d70c69cba9f2465459be/buildfile.nex
-  // Since then, I introduced the built-in Line() and Column() functions.
-  l, c int
-
   // The following line makes it easy for scripts to insert fields in the
   // generated code.
   // [NEX_END_OF_LEXER_STRUCT]

--- a/nex.go
+++ b/nex.go
@@ -771,6 +771,8 @@ type frame struct {
   s string
   line, column int
 }
+
+// Lexer is a generated lexer.
 type Lexer struct {
   // The lexer runs in its own goroutine, and communicates via channel 'ch'.
   ch chan frame
@@ -933,10 +935,12 @@ var dfas = []dfa{`
 
 var lexeroutro = `}
 
+// NewLexer creates a new default Lexer.
 func NewLexer(in io.Reader) *Lexer {
   return NewLexerWithInit(in, nil)
 }
 
+// Stop stops the lexer.
 func (yylex *Lexer) Stop() {
   yylex.chStop <- true
 }

--- a/nex_test.go
+++ b/nex_test.go
@@ -18,7 +18,7 @@ func TestGenStable(t *testing.T) {
 		var out bytes.Buffer
 
 		process(&out, bytes.NewBufferString(testinput))
-		e := "13f760d2f0dc1743dd7165781f2a318d"
+		e := "f2fef8e2a1c5eeb7c38f6e437be9ccac"
 		if x := fmt.Sprintf("%x", md5.Sum(out.Bytes())); x != e {
 			t.Errorf("got: %s wanted: %s", x, e)
 		}

--- a/test/nex_test.go
+++ b/test/nex_test.go
@@ -279,6 +279,7 @@ rect 11 12 16 17
 func TestGiantProgram(t *testing.T) {
 	tmpdir, err := ioutil.TempDir("", "nex")
 	dieErr(t, err, "TempDir")
+	dieErr(t, os.WriteFile(filepath.Join(tmpdir, "go.mod"), []byte("module nextest\n\ngo 1.23.4\n"), 0666), "WriteFile")
 	wd, err := os.Getwd()
 	dieErr(t, err, "Getwd")
 	dieErr(t, os.Chdir(tmpdir), "Chdir")
@@ -400,7 +401,7 @@ func TestGiantProgram(t *testing.T) {
 `, "abcdefghijmnopabcoq", "0ij1q"},
 	} {
 		id := fmt.Sprintf("%v", i)
-		s += `import "./nex_test` + id + "\"\n"
+		s += `import "nextest/nex_test` + id + "\"\n"
 		dieErr(t, os.Mkdir("nex_test"+id, 0777), "Mkdir")
 		// Ugly hack to import packages.
 		prog := x.prog

--- a/test/nex_test.go
+++ b/test/nex_test.go
@@ -34,6 +34,8 @@ func init() {
 }
 
 func dieErr(t *testing.T, err error, s string) {
+	t.Helper()
+
 	if err != nil {
 		t.Fatalf("%s: %s", s, err)
 	}
@@ -47,6 +49,8 @@ func TestNexPlusYacc(t *testing.T) {
 		dieErr(t, os.RemoveAll(tmpdir), "RemoveAll")
 	}()
 	run := func(s string) {
+		t.Helper()
+
 		v := strings.Split(s, " ")
 		err := exec.Command(v[0], v[1:]...).Run()
 		dieErr(t, err, s)


### PR DESCRIPTION
I was messing around with this testing something, and my IDE kept complaining about lint errors ... so rather than fix the output, I figured I'd patch and push it back in case useful to anyone else! Tests pass (I included a diff of the changes when I needed to update your checksum) and should be no functional change, but easier with standard tooling. Thanks for publishing this!